### PR TITLE
Specify Python version with pipx run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         with: {name: python-distribution-files, path: dist/}
       - name: Run tests
         run: >-
-          pipx run --python python --spec tox==3.27.1 tox
+          pipx run --verbose --python python --spec tox==3.27.1 tox
           --installpkg '${{ needs.prepare.outputs.wheel-distribution }}'
           -- -rFEx --durations 10 --color yes
       - name: Generate coverage report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,13 @@ jobs:
   test:
     needs: prepare
     strategy:
+      fail-fast: false
       matrix:
         python:
-        - "3.7"  # oldest Python supported by PSF
+        - 3.7     # oldest Python supported by PSF
+        - 3.8
+        - 3.9
+        - "3.10"
         - "3.11"  # newest Python that is stable
         platform:
         - ubuntu-latest
@@ -77,11 +81,11 @@ jobs:
         with: {name: python-distribution-files, path: dist/}
       - name: Run tests
         run: >-
-          pipx run --spec tox==3.27.1 tox
+          pipx run --python python${{ matrix.python }} --spec tox==3.27.1 tox
           --installpkg '${{ needs.prepare.outputs.wheel-distribution }}'
           -- -rFEx --durations 10 --color yes
       - name: Generate coverage report
-        run: pipx run coverage lcov -o coverage.lcov
+        run: pipx run --python python${{ matrix.python }} coverage lcov -o coverage.lcov
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,20 +74,22 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+        id: setup-python
         with:
           python-version: ${{ matrix.python }}
-      - name: Show Python path
-        run: echo ${{ steps.setup-python.outputs.python-path }}
       - name: Retrieve pre-built distribution files
         uses: actions/download-artifact@v3
         with: {name: python-distribution-files, path: dist/}
       - name: Run tests
         run: >-
-          pipx run --verbose --python python --spec tox==3.27.1 tox
+          pipx run --verbose --python '${{ steps.setup-python.outputs.python-path }}'
+          --spec tox==3.27.1 tox
           --installpkg '${{ needs.prepare.outputs.wheel-distribution }}'
           -- -rFEx --durations 10 --color yes
       - name: Generate coverage report
-        run: pipx run --python python coverage lcov -o coverage.lcov
+        run: >-
+          pipx run --python '${{ steps.setup-python.outputs.python-path }}'
+          coverage lcov -o coverage.lcov
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,11 +81,11 @@ jobs:
         with: {name: python-distribution-files, path: dist/}
       - name: Run tests
         run: >-
-          pipx run --python python${{ matrix.python }} --spec tox==3.27.1 tox
+          pipx run --python python --spec tox==3.27.1 tox
           --installpkg '${{ needs.prepare.outputs.wheel-distribution }}'
           -- -rFEx --durations 10 --color yes
       - name: Generate coverage report
-        run: pipx run --python python${{ matrix.python }} coverage lcov -o coverage.lcov
+        run: pipx run --python python coverage lcov -o coverage.lcov
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+      - name: Show Python path
+        run: echo ${{ steps.setup-python.outputs.python-path }}
       - name: Retrieve pre-built distribution files
         uses: actions/download-artifact@v3
         with: {name: python-distribution-files, path: dist/}


### PR DESCRIPTION
Apparently pipx run was using the system Python version instead of the one set up by the action setup-python. This commit specifies the Python version to run with pipx exactly.

Also run the tests on Python 3.8, 3.9 and 3.10 and don't fail fast.