### PR TITLE
Deprecate Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
-        - "3.7"   # oldest Python supported by PSF
-        - "3.8"
+        - "3.8"   # oldest Python supported by PSF
         - "3.9"
         - "3.10"
         - "3.11"  # newest Python that is stable

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -214,7 +214,7 @@ package:
     tox -r -e docs
 
 #. Make sure to have a reliable |tox|_ installation that uses the correct
-   Python version (e.g., 3.7+). When in doubt you can run::
+   Python version (e.g., 3.8+). When in doubt you can run::
 
     tox --version
     # OR

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ fixable = [
   "COM812",  # trailing comma missing
   "RUF001",  # ambiguous Unicode character
 ]
-# Always generate Python 3.7-compatible code
-target-version = "py37"
+# Always generate Python 3.8-compatible code
+target-version = "py38"
 
 src = ["src", "test"]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ classifiers =
 	Programming Language :: Python
 	Programming Language :: Python :: 3
 	Programming Language :: Python :: 3 :: Only
-	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
@@ -50,14 +49,13 @@ include_package_data = True
 package_dir =
     =src
 
-python_requires = >=3.7
+python_requires = >=3.8
 
 # Add here dependencies of your project (line-separated), e.g. requests>=2.2,<3.0.
 # Version specifiers like >=2.2,<3.0 avoid problems due to API changes in
 # new major versions. This works if the required packages follow Semantic Versioning.
 # For more information, check out https://semver.org/.
-install_requires =
-    importlib-metadata; python_version<"3.8"
+#install_requires =
 
 
 [options.packages.find]

--- a/src/bluetooth_numbers/__init__.py
+++ b/src/bluetooth_numbers/__init__.py
@@ -40,7 +40,6 @@ Get the description of an OUI:
 >>> oui["58:2D:34"]
 'Qingping Electronics (Suzhou) Co., Ltd'
 """
-import sys
 
 # Public API for easier importing
 from ._characteristics import characteristic
@@ -51,11 +50,7 @@ from ._services import service
 
 __all__ = ["characteristic", "company", "descriptor", "oui", "service"]
 
-if sys.version_info[:2] >= (3, 8):
-    # TODO: Import directly (no need for conditional) when `python_requires = >= 3.8`
-    from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
-else:
-    from importlib_metadata import PackageNotFoundError, version  # pragma: no cover
+from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
 
 try:
     # Change here if project is renamed and does not equal the package name


### PR DESCRIPTION
Python 3.7 is EOL since 2023-06-27: https://devguide.python.org/versions/