### PR TITLE
Update use of Ruff

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,0 @@
-[settings]
-profile = black
-known_first_party = bluetooth_numbers

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,16 +29,10 @@ repos:
     args: ['--fix=auto']  # replace 'auto' with 'lf' to enforce Linux/Mac line endings or 'crlf' for Windows
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.3
+  rev: v0.1.7
   hooks:
   - id: ruff-format
   - id: ruff
-
-- repo: https://github.com/econchick/interrogate
-  rev: 1.5.0
-  hooks:
-  - id: interrogate
-    args: [--verbose, --omit-covered-files, --fail-under=100]
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.6
@@ -47,7 +41,7 @@ repos:
     args: [--skip, "data/*,src/bluetooth_numbers/_*.py"]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.6.1
+  rev: v1.7.1
   hooks:
   - id: mypy
     entry: env MYPYPATH=src mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,6 @@ ignore = [
   "FBT",     # flake8-boolean-trap
 ]
 fix = true
-fixable = [
-  "COM812",  # trailing comma missing
-  "RUF001",  # ambiguous Unicode character
-]
 # Always generate Python 3.8-compatible code
 target-version = "py38"
 


### PR DESCRIPTION
* Let Ruff fix all fixable issues
* Remove interrogate as Ruff's pydocstyle should be enough
* Remove `.isort.cfg` file that isn't needed anymore

Fixes https://github.com/koenvervloesem/bluetooth-numbers/issues/44